### PR TITLE
Request cumulative value from scsi_log_sense().

### DIFF
--- a/cam.pyx
+++ b/cam.pyx
@@ -102,6 +102,7 @@ cdef get_unaligned_be32(void *p):
 class SCSILogSense(enum.IntEnum):
     TEMPERATURE = 0xd
     IE = 0x2f
+    CUMULATIVE = 0x40
 
 
 class SCSIReadOp(enum.IntEnum):
@@ -203,7 +204,7 @@ cdef class CamCCB(object):
     def scsi_mode_sense(self, **kwargs):
         pass
 
-    def scsi_log_sense(self, retries=0, page=0, page_code=0, paramptr=0, save_pages=False, ppc=0, data=None, timeout=None):
+    def scsi_log_sense(self, retries=0, page=SCSILogSense.CUMULATIVE.value, page_code=0, paramptr=0, save_pages=False, ppc=0, data=None, timeout=None):
         cdef uint32_t c_retries = retries
         cdef uint8_t c_page = page
         cdef uint8_t c_page_code = page_code

--- a/cam.pyx
+++ b/cam.pyx
@@ -164,7 +164,7 @@ cdef class CamCCB(object):
         cdef uint16_t c_sector_count = sector_count
         cdef uint8_t *c_data_ptr
         cdef uint16_t c_dxfer_len = len(data)
-        cdef uint32_t c_timeout = 5 * 1000
+        cdef uint32_t c_timeout = 30 * 1000
 
         with nogil:
             c_data_ptr = <uint8_t *>malloc(c_dxfer_len)
@@ -210,7 +210,7 @@ cdef class CamCCB(object):
         cdef uint8_t c_page_code = page_code
         cdef int c_save_pages = save_pages
         cdef int c_ppc = ppc
-        cdef uint32_t c_timeout = timeout or 5 * 1000
+        cdef uint32_t c_timeout = timeout or 60 * 1000
 
         cdef uint32_t c_param_ptr = paramptr
         cdef uint8_t *c_param_buf


### PR DESCRIPTION
Previous default (0) requested threshold value, obsolete now and
probably incorrect, causing error on some drives and particularly
by SATL in LSI HBAs.

Ticket:	NAS-105053