### PR TITLE
NAS-116654 / 13.0 / properly return namespace id if requested

### DIFF
--- a/nvme.pyx
+++ b/nvme.pyx
@@ -105,7 +105,7 @@ def get_nsid(path):
         if res == -1:
             raise OSError(errno.errno, os.strerror(errno.errno), path)
 
-        return nsid.cdev
+        return nsid.cdev, nsid.nsid
     finally:
         os.close(fd)
 


### PR DESCRIPTION
This function isn't returning the namespace ID and is only returning the nvme controller. This now will return a tuple of `(ctrl, nsid)` and the caller can decide if the nvme controller device needs to be used or the namespace id device needs to be used.